### PR TITLE
Add local test environments

### DIFF
--- a/test/local-test.html
+++ b/test/local-test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+ Copyright (c) 2020 The UsaCon Authors
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+            name="description"
+            content="usacon test page"
+    />
+    <script type="text/javascript" src="polyfill.js"></script>
+    <script type="text/javascript" src="content.bundle.js"></script>
+    <link rel="stylesheet" type="text/css" href="test.css">
+</head>
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+</body>
+</html>

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -15,12 +15,28 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#chrome-sacloud-console-root {
-    position: absolute;
-    top: 400px;
-    left: 200px;
-    display: block;
-    z-index: 1;
-    width: 1200px;
-    height: 400px;
+if (typeof global !== "undefined") {
+    // global already exists
+} else if (typeof window !== "undefined") {
+    window.global = window;
+} else if (typeof self !== "undefined") {
+    self.global = self;
+} else {
+    throw new Error("global undefined");
 }
+
+// polyfill extentions namespaces
+if (typeof global.chrome === "undefined") {
+    global.chrome = {};
+}
+
+if (typeof global.chrome.runtime === "undefined") {
+    global.chrome.runtime = {};
+}
+
+if (typeof global.chrome.runtime.getURL === "undefined") {
+    global.chrome.runtime.getURL = function(url) {
+        return "./" + url;
+    };
+}
+

--- a/test/test.css
+++ b/test/test.css
@@ -17,10 +17,12 @@
 
 #chrome-sacloud-console-root {
     position: absolute;
-    top: 400px;
-    left: 200px;
+    top: 0;
+    left: 0;
     display: block;
     z-index: 1;
     width: 1200px;
-    height: 400px;
+    height: 800px;
+    margin: 50px;
 }
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,13 +69,14 @@ module.exports = {
     devServer: {
         contentBase: `${__dirname}/dist`,
         watchContentBase: true,
-        open: true,
-        openPage:"popup.html"
+        open: "Google Chrome",
+        openPage:"local-test.html"
     },
     plugins: [
         new CopyPlugin({
             patterns: [
-                { from: 'public', to: './' }
+                {from: 'public', to: './'},
+                {from: 'test', to: './'},
             ],
         }),
     ],

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -62,7 +62,7 @@ module.exports = {
     plugins: [
         new CopyPlugin({
             patterns: [
-                { from: 'public', to: './' }
+                {from: 'public', to: './'}
             ],
         }),
     ],


### PR DESCRIPTION
コンソールのマニュアルでの動作確認を容易にするためにWeb Extensionsとしてではなく独立して起動できるようにする。

`yarn start`で開発用サーバが起動する。

Note:

- 暫定的に`chrome.runtime`にpolyfillを当てるようにしているが、今後複数ブラウザ対応時に合わせて対応する
- Chromeが起動するようにしてあるが、今後デフォルトのブラウザで開くように変更する。