### PR TITLE
Implements login/logout flow

### DIFF
--- a/src/components/APIKeyDialog.tsx
+++ b/src/components/APIKeyDialog.tsx
@@ -26,7 +26,7 @@ type Props = {
 
 const APIKeyDialog: React.FC<Props> = (props: Props) => {
   return (
-    <Dialog open={props.open}>
+    <Dialog open={props.open} onClose={props.onClose}>
       <APIKeyInput onClose={props.onClose} />
     </Dialog>
   );

--- a/src/components/BottomDrawer.tsx
+++ b/src/components/BottomDrawer.tsx
@@ -17,12 +17,19 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Drawer from "@material-ui/core/Drawer";
-import { AppBar, IconButton, Toolbar } from "@material-ui/core";
+import {
+  AppBar,
+  IconButton,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
 import CancelRoundedIcon from "@material-ui/icons/CancelRounded";
-import VpnKeyRoundedIcon from "@material-ui/icons/VpnKeyRounded";
 import APIKeyDialog from "./APIKeyDialog";
 import ConsoleWrapper from "./ConsoleWrapper";
 import { Usacon } from "../usacon";
+import CurrentAPIKey from "./CurrentAPIKey";
+import { AddCircleRounded } from "@material-ui/icons";
 
 const defaultDrawerHeight = 500;
 const minDrawerHeight = 50;
@@ -31,6 +38,7 @@ const maxDrawerHeight = 800;
 const useStyles = makeStyles((theme) => ({
   toolBar: {
     minHeight: 48,
+    paddingRight: 5,
   },
   logo: {
     maxHeight: 40,
@@ -56,7 +64,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export type BottomDrawerProps = {};
+export type BottomDrawerProps = {
+  usacon: Usacon;
+};
 
 const BottomDrawer: React.FC<BottomDrawerProps> = (props) => {
   const classes = useStyles();
@@ -64,7 +74,6 @@ const BottomDrawer: React.FC<BottomDrawerProps> = (props) => {
   const [drawerHeight, setDrawerHeight] = React.useState(defaultDrawerHeight);
   const [apiKeyInputOpen, setAPIKeyInputOpen] = React.useState(false);
   const ref = React.createRef<HTMLDivElement>();
-  const usacon = new Usacon();
 
   useEffect(() => {
     const consoleRoot = ref.current;
@@ -74,8 +83,8 @@ const BottomDrawer: React.FC<BottomDrawerProps> = (props) => {
         message.type === "usacon.toggleConsoleVisible"
       ) {
         setOpen((current) => !current);
-        if (consoleRoot && !usacon.isOpen) {
-          usacon.open(consoleRoot);
+        if (consoleRoot && !props.usacon.isOpen) {
+          props.usacon.open(consoleRoot);
         }
       }
     });
@@ -97,11 +106,12 @@ const BottomDrawer: React.FC<BottomDrawerProps> = (props) => {
     const newHeight = window.innerHeight - e.clientY;
     if (newHeight > minDrawerHeight && newHeight < maxDrawerHeight) {
       setDrawerHeight(newHeight);
-      usacon.term.fit();
+      props.usacon.term.fit();
     }
   }, []);
 
   const handleAPIKeyButtonClick = () => {
+    navigator.credentials.preventSilentAccess();
     setAPIKeyInputOpen(true);
   };
 
@@ -132,20 +142,26 @@ const BottomDrawer: React.FC<BottomDrawerProps> = (props) => {
               className={classes.logo}
             />
             <div className={classes.icons}>
-              <IconButton
-                edge="start"
-                color="primary"
-                onClick={handleAPIKeyButtonClick}
-              >
-                <VpnKeyRoundedIcon />
-              </IconButton>
-              <IconButton
-                edge="start"
-                color="secondary"
-                onClick={handleCloseButtonClick}
-              >
-                <CancelRoundedIcon />
-              </IconButton>
+              <CurrentAPIKey usacon={props.usacon} />
+              <Tooltip title="Add API Key">
+                <IconButton
+                  edge="start"
+                  color="inherit"
+                  onClick={handleAPIKeyButtonClick}
+                >
+                  <AddCircleRounded />
+                  <Typography variant="body1">Add API Key</Typography>
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Close">
+                <IconButton
+                  edge="start"
+                  color="default"
+                  onClick={handleCloseButtonClick}
+                >
+                  <CancelRoundedIcon />
+                </IconButton>
+              </Tooltip>
             </div>
           </Toolbar>
         </AppBar>

--- a/src/components/CurrentAPIKey.tsx
+++ b/src/components/CurrentAPIKey.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2020 The UsaCon Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useState } from "react";
+import { IconButton, Tooltip, Typography } from "@material-ui/core";
+import { AccountCircle, VpnKeyRounded } from "@material-ui/icons";
+import APIKey from "../api-key";
+import { getAPIKey } from "../credential";
+import { makeStyles } from "@material-ui/core/styles";
+import { Usacon } from "../usacon";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "inline",
+  },
+}));
+
+type Props = {
+  usacon: Usacon;
+};
+
+const CurrentAPIKey: React.FC<Props> = (props: Props) => {
+  const classes = useStyles();
+  const [apiKey, setAPIKey] = useState(new APIKey());
+
+  const handleLogin = () => {
+    navigator.credentials.preventSilentAccess();
+    getAPIKey(true).then((cred) => {
+      if (cred !== null) {
+        const newKey = new APIKey({
+          token: cred.id as string,
+          secret: cred.password as string,
+          name: cred.name as string,
+          errors: new Map<string, string>(),
+        });
+        props.usacon.apiKey = newKey;
+        setAPIKey(newKey);
+      } else {
+        props.usacon.apiKey = undefined;
+        setAPIKey(new APIKey());
+        navigator.credentials.preventSilentAccess();
+      }
+    });
+  };
+
+  const handleLogout = () => {
+    props.usacon.apiKey = undefined;
+    setAPIKey(new APIKey());
+    navigator.credentials.preventSilentAccess();
+  };
+
+  return (
+    <div className={classes.root}>
+      {props.usacon.apiKey ? (
+        <Tooltip title="Click to logout">
+          <IconButton
+            aria-label="Current API key"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleLogout}
+            color="primary"
+          >
+            <AccountCircle />
+            <Typography variant="body1">{apiKey.name}</Typography>
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <IconButton onClick={handleLogin} color="primary">
+          <VpnKeyRounded />
+          <Typography variant="body1">Choose API Key</Typography>
+        </IconButton>
+      )}
+    </div>
+  );
+};
+
+export default CurrentAPIKey;

--- a/src/content.ts
+++ b/src/content.ts
@@ -20,6 +20,7 @@ import ReactDOM from "react-dom";
 import BottomDrawer from "./components/BottomDrawer";
 import "./css/xterm.css";
 import "./css/xterm_customize.css";
+import { Usacon } from "./usacon";
 
 const rootId = "chrome-sacloud-console-root";
 
@@ -31,7 +32,7 @@ function createRootElement() {
   parents[0].appendChild(root);
 
   ReactDOM.render(
-    React.createElement(BottomDrawer, {}, null),
+    React.createElement(BottomDrawer, { usacon: new Usacon() }, null),
     document.getElementById(rootId)
   );
 }


### PR DESCRIPTION
fixes #28 

#28の実装

#### ログイン前
<img width="1792" alt="before" src="https://user-images.githubusercontent.com/1644816/84388744-0a556e00-ac30-11ea-80ee-ecdc80313241.png">


#### ログイン後

<img width="1792" alt="after" src="https://user-images.githubusercontent.com/1644816/84388748-0cb7c800-ac30-11ea-97b0-ae8c253a8e09.png">


Note: 

- ログアウトの確認を出していないが、ログイン自体は1クリックで済むため気軽にできるものとして確認ダイアログは出さないことにした
- APIキー未設定時(ログアウト状態)ではUsacloudのFakeモードを有効にするようにした
