### PR TITLE
Added help button

### DIFF
--- a/src/components/ConsoleToolBar.tsx
+++ b/src/components/ConsoleToolBar.tsx
@@ -88,6 +88,18 @@ const ConsoleToolBar: React.FC<ConsoleToolbarProps> = (props) => {
     setLicenseWindowOpen(true);
   };
 
+  const openHelpPage = () => {
+    const newWindow = window.open(
+      "https://docs.usacloud.jp/usacon/#usage",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    if (newWindow) {
+      newWindow.opener = null;
+    }
+    handleMoreMenuClose();
+  };
+
   return (
     <AppBar color={"default"} position={"relative"}>
       <Toolbar className={classes.toolBar}>
@@ -131,6 +143,9 @@ const ConsoleToolBar: React.FC<ConsoleToolbarProps> = (props) => {
             open={moreMenuOpen}
             onClose={handleMoreMenuClose}
           >
+            <MenuItem onClick={openHelpPage} divider={true}>
+              Help / Documents
+            </MenuItem>
             <MenuItem onClick={handleLicenseWindowOpen}>
               Open source licenses
             </MenuItem>


### PR DESCRIPTION
closes #33 

Usaconドキュメントを開くためのボタンを追加する。

<img width="449" alt="image" src="https://user-images.githubusercontent.com/1644816/102688042-6e886880-4237-11eb-9262-45bcf6b2064f.png">
