### PR TITLE
Disable fallback to Fake mode

### DIFF
--- a/src/usacon.ts
+++ b/src/usacon.ts
@@ -112,8 +112,6 @@ export class Usacon {
     if (this.apiKey) {
       additionalEnvs.set("SAKURACLOUD_ACCESS_TOKEN", this.apiKey.token);
       additionalEnvs.set("SAKURACLOUD_ACCESS_TOKEN_SECRET", this.apiKey.secret);
-    } else {
-      additionalEnvs.set("SAKURACLOUD_FAKE_MODE", "1");
     }
     additionalEnvs.set("SAKURACLOUD_ZONE", this.zoneName);
 


### PR DESCRIPTION
APIキーが設定されていない場合にFakeドライバーを有効にする環境変数を設定していたのを無効にする。
これによりAPIキーが設定されていない場合は通常のバリデーションエラーとなる。