### PR TITLE
Fake implementation for global.process.cwd()

### DIFF
--- a/src/wasm-terminal/command/go/polyfill.js
+++ b/src/wasm-terminal/command/go/polyfill.js
@@ -65,7 +65,7 @@ export function polyfillForGolang(fs) {
         throw enosys();
       },
       cwd() {
-        throw enosys();
+        return "/";
       },
       chdir() {
         throw enosys();


### PR DESCRIPTION
closes #59 

Goから呼ばれる`global.process.cwd()`にダミー実装を設定する。