### PR TITLE
Supports SharedArrayBuffer for Chrome 91+

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "icons": {
     "128": "icon_128.png"
   },
-  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas*"],
+  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas*", "https://munchkin.marketo.net/*", "https://s.yimg.jp/*", "webRequest", "webRequestBlocking"],
   "content_scripts" : [
     {
       "matches": [ "https://secure.sakura.ad.jp/cloud/iaas*" ],
@@ -15,7 +15,7 @@
   ],
   "background": {
     "scripts": ["background.bundle.js"],
-    "persistent": false
+    "persistent": true
   },
   "page_action": {
     "browser_style": true,

--- a/src/background.ts
+++ b/src/background.ts
@@ -37,3 +37,45 @@ chrome.pageAction.onClicked.addListener((tab) => {
     });
   }
 });
+
+// set response header modifier for set COOP/COEP header
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!details.responseHeaders) {
+      return;
+    }
+    details.responseHeaders.push({
+      name: "Cross-Origin-Embedder-Policy",
+      value: "require-corp",
+    });
+    details.responseHeaders.push({
+      name: "Cross-Origin-Opener-Policy",
+      value: "same-origin",
+    });
+    return { responseHeaders: details.responseHeaders };
+  },
+  { urls: ["https://secure.sakura.ad.jp/cloud/iaas/"] },
+  ["blocking", "responseHeaders", "extraHeaders"]
+);
+
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!details.responseHeaders) {
+      return;
+    }
+    const header = details.responseHeaders.find(
+      (h) => h.name.toLowerCase() === "cross-origin-resource-policy"
+    );
+    if (header) {
+      header.value = "cross-origin";
+    } else {
+      details.responseHeaders.push({
+        name: "Cross-Origin-Resource-Policy",
+        value: "cross-origin",
+      });
+    }
+    return { responseHeaders: details.responseHeaders };
+  },
+  { urls: ["https://s.yimg.jp/*", "https://munchkin.marketo.net/*"] },
+  ["blocking", "responseHeaders", "extraHeaders"]
+);


### PR DESCRIPTION
#62 対応

usaconの対象ページ(`https://secure.sakura.ad.jp/cloud/`)は`self.crossOriginIsolated`がfalseであり、SharedArrayBufferが利用できない。このためextension側でdocumentに対するレスポンスをフックしCOOP/COEPヘッダを注入することでクロスオリジン分離を疑似的に実現しSharedArrayBufferを利用可能にする。

### 主な変更内容

- backgroundスクリプトにて[webRequest API](https://developer.mozilla.org/ja/docs/Mozilla/Add-ons/WebExtensions/API/webRequest)を用いて`https://secure.sakura.ad.jp/cloud/`に対するレスポンスヘッダとしてCOOP/COEPヘッダーを注入
- 上記の副作用としてscriptタグで指定しているスクリプトがエラーとなるため、対象スクリプトを提供するオリジンごとにホワイトリスト方式でレスポンスヘッダに`Cross-Origin-Resource-Policy: cross-origin`を注入(上記と同じwebRequest APIを用いる)
- 上記の処理を行える様にマニフェストの`permissions`に以下4つを追加
  - "https://munchkin.marketo.net/*"
  - "https://s.yimg.jp/*"
  - "webRequest"
  - "webRequestBlocking"
- 同じく動作できる様に`background.persistant: true`へ変更

### 副作用/デメリットなど

~- 他のscriptなどをクロスドメインで読み込む際にエラーが発生する可能性あり(実際に発生している模様)~( 61f1912a8be2756ca6c46fc4899dcc82671e61b8 で解消済み)
- マニフェストのpermissionsが増えているため配布にあたりストアでの再審査が必要
- マニフェストの`background.persistent`をtrueにする必要があり、バックグラウンドページが永続化(メモリ常駐)されてしまう