### PR TITLE
Remove request hooks and permissions for origins other than secure.sakura.ad.jp

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "icons": {
     "128": "icon_128.png"
   },
-  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas*", "https://munchkin.marketo.net/*", "https://s.yimg.jp/*", "webRequest", "webRequestBlocking"],
+  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas*", "webRequest", "webRequestBlocking"],
   "content_scripts" : [
     {
       "matches": [ "https://secure.sakura.ad.jp/cloud/iaas*" ],

--- a/src/background.ts
+++ b/src/background.ts
@@ -57,25 +57,3 @@ chrome.webRequest.onHeadersReceived.addListener(
   { urls: ["https://secure.sakura.ad.jp/cloud/iaas/"] },
   ["blocking", "responseHeaders", "extraHeaders"]
 );
-
-chrome.webRequest.onHeadersReceived.addListener(
-  (details) => {
-    if (!details.responseHeaders) {
-      return;
-    }
-    const header = details.responseHeaders.find(
-      (h) => h.name.toLowerCase() === "cross-origin-resource-policy"
-    );
-    if (header) {
-      header.value = "cross-origin";
-    } else {
-      details.responseHeaders.push({
-        name: "Cross-Origin-Resource-Policy",
-        value: "cross-origin",
-      });
-    }
-    return { responseHeaders: details.responseHeaders };
-  },
-  { urls: ["https://s.yimg.jp/*", "https://munchkin.marketo.net/*"] },
-  ["blocking", "responseHeaders", "extraHeaders"]
-);


### PR DESCRIPTION
follow up #63 

secure.sakura.ad.jp以外へのリクエストフックとパーミッションを除去する。  
コントロールパネルを開いた際にエラーとなるがこの拡張側で`munchkin.marketo.net`や`s.yimg.jp`を直接利用していないのにフック/パーミッション設定を行うことは適切ではないと判断した。  
