### PR TITLE
Fixed an issue where the console iframe could not be opened

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "icons": {
     "128": "icon_128.png"
   },
-  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas*", "webRequest", "webRequestBlocking"],
+  "permissions": ["https://secure.sakura.ad.jp/cloud/iaas/*", "https://*.cloud.sakura.ad.jp/*","webRequest", "webRequestBlocking"],
   "content_scripts" : [
     {
       "matches": [ "https://secure.sakura.ad.jp/cloud/iaas*" ],

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,6 +44,13 @@ chrome.webRequest.onHeadersReceived.addListener(
     if (!details.responseHeaders) {
       return;
     }
+    if (
+      !details.responseHeaders.some(
+        (h) => h.name === "Content-Type" && h.value?.startsWith("text/html")
+      )
+    ) {
+      return;
+    }
     details.responseHeaders.push({
       name: "Cross-Origin-Embedder-Policy",
       value: "require-corp",
@@ -54,6 +61,26 @@ chrome.webRequest.onHeadersReceived.addListener(
     });
     return { responseHeaders: details.responseHeaders };
   },
-  { urls: ["https://secure.sakura.ad.jp/cloud/iaas/"] },
+  {
+    urls: ["https://secure.sakura.ad.jp/cloud/iaas/*"],
+  },
+  ["blocking", "responseHeaders", "extraHeaders"]
+);
+
+// set response header modifier for set CORP header
+chrome.webRequest.onHeadersReceived.addListener(
+  (details) => {
+    if (!details.responseHeaders) {
+      return;
+    }
+    details.responseHeaders.push({
+      name: "Cross-Origin-Resource-Policy",
+      value: "cross-origin",
+    });
+    return { responseHeaders: details.responseHeaders };
+  },
+  {
+    urls: ["https://*.cloud.sakura.ad.jp/*"],
+  },
   ["blocking", "responseHeaders", "extraHeaders"]
 );


### PR DESCRIPTION
  - Header injection is now limited to Content-Type: text/html
  - Added wildcards to the end of URLs targeted for header injection
  - Inject CORP header to https://*.cloud.sakura.ad.jp/*
 
---

COEPヘッダによりサーバ詳細画面の`コンソール`部のiframeが開けない問題を修正

- ヘッダ注入対象URLに末尾にワイルドカード付与して対象を拡大
- COOP/COEPヘッダ注入対象を`Content-Type: text/html`がレスポンスに含まれるもののみに限定
- `https://*.cloud.sakura.ad.jp/*`からのレスポンスヘッダに`Cross-Origin-Resource-Policy: cross-origin`を注入

Note: 

- サーバ詳細画面のコンソール部で「リモートスクリーンに接続」->「HTML5モード」とすると`https://*.cloud.sakura.ad.jp`へのリクエストが発生する。このレスポンスにCORPヘッダとして`Cross-Origin-Resource-Policy: cross-origin`を注入することでCOEPヘッダ`require-corp`による動作に対応させる。

- `https://*.cloud.sakura.ad.jp`へのリクエストはゾーンごとにホスト名が異なる、かついくつかのスクリプトを読み込んでいるためURLパターンとして`https://*.cloud.sakura.ad.jp/*`とした