### PR TITLE
Inject COEP header for content with Content-Type: text/javascript

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -46,7 +46,10 @@ chrome.webRequest.onHeadersReceived.addListener(
     }
     if (
       !details.responseHeaders.some(
-        (h) => h.name === "Content-Type" && h.value?.startsWith("text/html")
+        (h) =>
+          h.name === "Content-Type" &&
+          (h.value?.startsWith("text/html") ||
+            h.value?.startsWith("text/javascript"))
       )
     ) {
       return;


### PR DESCRIPTION
一部WebWorker用のjsの読み込みでエラーが出ていた問題を修正

従来は特定ドメイン配下、かつContent-Typeが`text/html`のコンテンツにのみCOEPヘッダを注入していたが、
Content-Typeが`text/javascript`の場合も対象とするように修正。